### PR TITLE
BREAKING CHANGE: Rename Scope to ExecutionPolicyScope

### DIFF
--- a/DSCResources/MSFT_xPowerShellExecutionPolicy/MSFT_xPowerShellExecutionPolicy.psm1
+++ b/DSCResources/MSFT_xPowerShellExecutionPolicy/MSFT_xPowerShellExecutionPolicy.psm1
@@ -1,17 +1,17 @@
-#--------------------------------------------------------------------------------- 
-#The sample scripts are not supported under any Microsoft standard support 
-#program or service. The sample scripts are provided AS IS without warranty  
-#of any kind. Microsoft further disclaims all implied warranties including,  
-#without limitation, any implied warranties of merchantability or of fitness for 
-#a particular purpose. The entire risk arising out of the use or performance of  
-#the sample scripts and documentation remains with you. In no event shall 
-#Microsoft, its authors, or anyone else involved in the creation, production, or 
-#delivery of the scripts be liable for any damages whatsoever (including, 
-#without limitation, damages for loss of business profits, business interruption, 
-#loss of business information, or other pecuniary loss) arising out of the use 
-#of or inability to use the sample scripts or documentation, even if Microsoft 
-#has been advised of the possibility of such damages 
-#--------------------------------------------------------------------------------- 
+#---------------------------------------------------------------------------------
+#The sample scripts are not supported under any Microsoft standard support
+#program or service. The sample scripts are provided AS IS without warranty
+#of any kind. Microsoft further disclaims all implied warranties including,
+#without limitation, any implied warranties of merchantability or of fitness for
+#a particular purpose. The entire risk arising out of the use or performance of
+#the sample scripts and documentation remains with you. In no event shall
+#Microsoft, its authors, or anyone else involved in the creation, production, or
+#delivery of the scripts be liable for any damages whatsoever (including,
+#without limitation, damages for loss of business profits, business interruption,
+#loss of business information, or other pecuniary loss) arising out of the use
+#of or inability to use the sample scripts or documentation, even if Microsoft
+#has been advised of the possibility of such damages
+#---------------------------------------------------------------------------------
 
 function Get-TargetResource
 {
@@ -26,13 +26,13 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet("CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy")]
         [System.String]
-        $ScopeLevel = 'LocalMachine'
+        $ExecutionPolicyScope = 'LocalMachine'
     )
-    
+
     #Gets the execution policies for the current session.
     $returnValue = @{
-        ExecutionPolicy = $(Get-ExecutionPolicy -Scope $ScopeLevel)
-        ScopeLevel = $ScopeLevel
+        ExecutionPolicy = $(Get-ExecutionPolicy -Scope $ExecutionPolicyScope)
+        ExecutionPolicyScope = $ExecutionPolicyScope
     }
 
     $returnValue
@@ -51,15 +51,15 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet("CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy")]
         [System.String]
-        $ScopeLevel = 'LocalMachine'
+        $ExecutionPolicyScope = 'LocalMachine'
     )
-    
+
     If($PSCmdlet.ShouldProcess("$ExecutionPolicy","Set-ExecutionPolicy"))
     {
         Try
         {
             Write-Verbose "Setting the execution policy of PowerShell."
-            Set-ExecutionPolicy -ExecutionPolicy $ExecutionPolicy -Force -ErrorAction Stop -Scope $ScopeLevel
+            Set-ExecutionPolicy -ExecutionPolicy $ExecutionPolicy -Force -ErrorAction Stop -Scope $ExecutionPolicyScope
         }
         Catch
         {
@@ -89,10 +89,10 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet("CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy")]
         [System.String]
-        $ScopeLevel = 'LocalMachine'
+        $ExecutionPolicyScope = 'LocalMachine'
     )
 
-    If($(Get-ExecutionPolicy -Scope $ScopeLevel) -eq $ExecutionPolicy)
+    If($(Get-ExecutionPolicy -Scope $ExecutionPolicyScope) -eq $ExecutionPolicy)
     {
         return $true
     }
@@ -103,4 +103,3 @@ function Test-TargetResource
 }
 
 Export-ModuleMember -Function *-TargetResource
-

--- a/DSCResources/MSFT_xPowerShellExecutionPolicy/MSFT_xPowerShellExecutionPolicy.psm1
+++ b/DSCResources/MSFT_xPowerShellExecutionPolicy/MSFT_xPowerShellExecutionPolicy.psm1
@@ -26,13 +26,13 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet("CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy")]
         [System.String]
-        $Scope = 'LocalMachine'
+        $ScopeLevel = 'LocalMachine'
     )
     
     #Gets the execution policies for the current session.
     $returnValue = @{
-        ExecutionPolicy = $(Get-ExecutionPolicy -Scope $Scope)
-        Scope = $Scope
+        ExecutionPolicy = $(Get-ExecutionPolicy -Scope $ScopeLevel)
+        ScopeLevel = $ScopeLevel
     }
 
     $returnValue
@@ -51,7 +51,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet("CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy")]
         [System.String]
-        $Scope = 'LocalMachine'
+        $ScopeLevel = 'LocalMachine'
     )
     
     If($PSCmdlet.ShouldProcess("$ExecutionPolicy","Set-ExecutionPolicy"))
@@ -59,7 +59,7 @@ function Set-TargetResource
         Try
         {
             Write-Verbose "Setting the execution policy of PowerShell."
-            Set-ExecutionPolicy -ExecutionPolicy $ExecutionPolicy -Force -ErrorAction Stop -Scope $Scope
+            Set-ExecutionPolicy -ExecutionPolicy $ExecutionPolicy -Force -ErrorAction Stop -Scope $ScopeLevel
         }
         Catch
         {
@@ -89,10 +89,10 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet("CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy")]
         [System.String]
-        $Scope = 'LocalMachine'
+        $ScopeLevel = 'LocalMachine'
     )
 
-    If($(Get-ExecutionPolicy -Scope $Scope) -eq $ExecutionPolicy)
+    If($(Get-ExecutionPolicy -Scope $ScopeLevel) -eq $ExecutionPolicy)
     {
         return $true
     }

--- a/DSCResources/MSFT_xPowerShellExecutionPolicy/MSFT_xPowerShellExecutionPolicy.schema.mof
+++ b/DSCResources/MSFT_xPowerShellExecutionPolicy/MSFT_xPowerShellExecutionPolicy.schema.mof
@@ -3,7 +3,7 @@
 class MSFT_xPowerShellExecutionPolicy : OMI_BaseResource
 {
     [Key, Description("Changes the preference for the Windows PowerShell execution policy."), ValueMap{"Bypass","Restricted","AllSigned","RemoteSigned","Unrestricted"}, Values{"Bypass","Restricted","AllSigned","RemoteSigned","Unrestricted"}] String ExecutionPolicy;
-    [Write, Description("Defines the scope for the preference of the Windows PowerShell execution policy."), ValueMap{"CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy"},Values{"CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy"}] String Scope;
+    [Write, Description("Defines the scope for the preference of the Windows PowerShell execution policy."), ValueMap{"CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy"},Values{"CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy"}] String ScopeLevel;
 };
 
 

--- a/DSCResources/MSFT_xPowerShellExecutionPolicy/MSFT_xPowerShellExecutionPolicy.schema.mof
+++ b/DSCResources/MSFT_xPowerShellExecutionPolicy/MSFT_xPowerShellExecutionPolicy.schema.mof
@@ -3,7 +3,7 @@
 class MSFT_xPowerShellExecutionPolicy : OMI_BaseResource
 {
     [Key, Description("Changes the preference for the Windows PowerShell execution policy."), ValueMap{"Bypass","Restricted","AllSigned","RemoteSigned","Unrestricted"}, Values{"Bypass","Restricted","AllSigned","RemoteSigned","Unrestricted"}] String ExecutionPolicy;
-    [Write, Description("Defines the scope for the preference of the Windows PowerShell execution policy."), ValueMap{"CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy"},Values{"CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy"}] String ScopeLevel;
+    [Write, Description("Defines the scope for the preference of the Windows PowerShell execution policy."), ValueMap{"CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy"},Values{"CurrentUser","LocalMachine","MachinePolicy","Process","UserPolicy"}] String ExecutionPolicyScope;
 };
 
 

--- a/Examples/1-SetPowerShellExecutionPolicy.ps1
+++ b/Examples/1-SetPowerShellExecutionPolicy.ps1
@@ -1,6 +1,6 @@
 <#
 .EXAMPLE
-    This example shows how to configure powershell's execution policy.
+    This example shows how to configure powershell's execution policy for the specified scope level.
 #>
 
 Configuration Example

--- a/Examples/1-SetPowerShellExecutionPolicy.ps1
+++ b/Examples/1-SetPowerShellExecutionPolicy.ps1
@@ -1,6 +1,6 @@
 <#
 .EXAMPLE
-    This example shows how to configure powershell's execution policy for the specified scope level.
+    This example shows how to configure powershell's execution policy for the specified execution policy scope.
 #>
 
 Configuration Example
@@ -17,8 +17,8 @@ Configuration Example
     {
         xPowerShellExecutionPolicy ExecutionPolicy
         {
-            ExecutionPolicy = 'RemoteSigned'
-            ScopeLevel      = 'LocalMachine'
+            ExecutionPolicy      = 'RemoteSigned'
+            ExecutionPolicyScope = 'LocalMachine'
         }
     }
 }

--- a/Examples/1-SetPowerShellExecutionPolicy.ps1
+++ b/Examples/1-SetPowerShellExecutionPolicy.ps1
@@ -5,12 +5,6 @@
 
 Configuration Example
 {
-    param(
-        [Parameter(Mandatory = $true)]
-        [System.Management.Automation.PSCredential]
-        $SqlCredential
-    )
-
     Import-DscResource -ModuleName xPowerShellExecutionPolicy
 
     Node localhost

--- a/Examples/1-SetPowerShellExecutionPolicy.ps1
+++ b/Examples/1-SetPowerShellExecutionPolicy.ps1
@@ -1,0 +1,24 @@
+<#
+.EXAMPLE
+    This example shows how to configure powershell's execution policy.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $SqlCredential
+    )
+
+    Import-DscResource -ModuleName xPowerShellExecutionPolicy
+
+    Node localhost
+    {
+        xPowerShellExecutionPolicy ExecutionPolicy
+        {
+            ExecutionPolicy = 'RemoteSigned'
+            ScopeLevel      = 'LocalMachine'
+        }
+    }
+}

--- a/Examples/2-SetPowerShellExecutionPolicyWithoutScopeLevel.ps1
+++ b/Examples/2-SetPowerShellExecutionPolicyWithoutScopeLevel.ps1
@@ -5,12 +5,6 @@
 
 Configuration Example
 {
-    param(
-        [Parameter(Mandatory = $true)]
-        [System.Management.Automation.PSCredential]
-        $SqlCredential
-    )
-
     Import-DscResource -ModuleName xPowerShellExecutionPolicy
 
     Node localhost

--- a/Examples/2-SetPowerShellExecutionPolicyWithoutScopeLevel.ps1
+++ b/Examples/2-SetPowerShellExecutionPolicyWithoutScopeLevel.ps1
@@ -1,0 +1,23 @@
+<#
+.EXAMPLE
+    This example shows how to configure powershell's execution policy using the default scope level.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $SqlCredential
+    )
+
+    Import-DscResource -ModuleName xPowerShellExecutionPolicy
+
+    Node localhost
+    {
+        xPowerShellExecutionPolicy ExecutionPolicy
+        {
+            ExecutionPolicy = 'RemoteSigned'
+        }
+    }
+}

--- a/Examples/SetPowerShellExecutionPolicy.ps1
+++ b/Examples/SetPowerShellExecutionPolicy.ps1
@@ -1,27 +1,0 @@
-#--------------------------------------------------------------------------------- #The sample scripts are not supported under any Microsoft standard support #program or service. The sample scripts are provided AS IS without warranty  #of any kind. Microsoft further disclaims all implied warranties including,  #without limitation, any implied warranties of merchantability or of fitness for #a particular purpose. The entire risk arising out of the use or performance of  #the sample scripts and documentation remains with you. In no event shall #Microsoft, its authors, or anyone else involved in the creation, production, or #delivery of the scripts be liable for any damages whatsoever (including, #without limitation, damages for loss of business profits, business interruption, #loss of business information, or other pecuniary loss) arising out of the use #of or inability to use the sample scripts or documentation, even if Microsoft #has been advised of the possibility of such damages #--------------------------------------------------------------------------------- 
-
-Configuration SetPowerShellExecutionPolicy
-{
-    Param
-    (
-        #Target nodes to apply the configuration  
-        [String[]]$NodeName = $env:COMPUTERNAME,
-        
-        #Changes the user preference for the Windows PowerShell execution policy.
-        [Parameter(Mandatory)]
-        [ValidateSet("Bypass","Restricted","AllSigned","RemoteSigned","Unrestricted")]
-        [String]$SetExecutionPolicy
-    )
-    Import-DSCResource -ModuleName xPowerShellExecutionPolicy
-
-    Node $NodeName
-    {
-        xPowerShellExecutionPolicy ExecutionPolicy
-        {
-            ExecutionPolicy = $SetExecutionPolicy
-        }
-    }
-}
-
-SetPowerShellExecutionPolicy -NodeName "localhost" -SetExecutionPolicy "bypass"
-Start-DscConfiguration -Path .\SetPowerShellExecutionPolicy  -Wait -Force -Verbose

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   * Fixed PSSA Issues as well.
   * Fixed Markdown Linting issues as well.
 * [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode): Enabled Code Coverage Support ([issue #18](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/18)).
-* [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode): Renamed the 'Scope' Parameter to 'ScopeLevel' since errors are thrown when the MOF file is parsed because 'Scope' is a reserved keyword in the DMTF Specification. ([issue #14](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/14)).
+* [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode) BREAKING CHANGE: Renamed the 'Scope' Parameter to 'ScopeLevel' since errors are thrown when the MOF file is parsed because 'Scope' is a reserved keyword in the DMTF Specification. ([issue #14](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/14)).
 
 ### 2.0.0.0
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
-* [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode): Fixed bug in which unit tests were not being run and also when run would have failed ([issue #17](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/17)).
+* Fixed bug in which unit tests were not being run and also when run would have failed ([issue #17](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/17)). [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode)
   * Fixed PSSA Issues as well.
   * Fixed Markdown Linting issues as well.
-* [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode): Enabled Code Coverage Support ([issue #18](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/18)).
-* [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode) BREAKING CHANGE: Renamed the 'Scope' Parameter to 'ScopeLevel' since errors are thrown when the MOF file is parsed because 'Scope' is a reserved keyword in the DMTF Specification. ([issue #14](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/14)).
+* Enabled Code Coverage Support ([issue #18](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/18)). [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode)
+* BREAKING CHANGE: Renamed the 'Scope' Parameter to 'ScopeLevel' since errors are thrown when the MOF file is parsed because 'Scope' is a reserved keyword in the DMTF Specification. ([issue #14](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/14)). [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode)
 
 ### 2.0.0.0
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ### xPowerShellExecutionPolicy
 
 * **ExecutionPolicy**: Specifies the desired PowerShell execution policy.
-* **ScopeLevel**: Specifies the scope of the desired PowerShell execution policy. Defaults to 'LocalMachine'.
+* **ExecutionPolicyScope**: Specifies the scope of the desired PowerShell execution policy. Defaults to 'LocalMachine'.
 
 ## Versions
 
@@ -44,7 +44,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   * Fixed PSSA Issues as well.
   * Fixed Markdown Linting issues as well.
 * Enabled Code Coverage Support ([issue #18](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/18)). [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode)
-* BREAKING CHANGE: Renamed the 'Scope' Parameter to 'ScopeLevel' since errors are thrown when the MOF file is parsed because 'Scope' is a reserved keyword in the DMTF Specification. ([issue #14](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/14)). [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode)
+* BREAKING CHANGE: Renamed the 'Scope' Parameter to 'ExecutionPolicyScope' since errors are thrown when the MOF file is parsed because 'Scope' is a reserved keyword in the DMTF Specification. ([issue #14](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/14)). [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode)
 
 ### 2.0.0.0
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ### xPowerShellExecutionPolicy
 
 * **ExecutionPolicy**: Specifies the desired PowerShell execution policy.
-* **Scope**: Specifies the scope of the desired PowerShell execution policy. Defaults to 'LocalMachine'.
+* **ScopeLevel**: Specifies the scope of the desired PowerShell execution policy. Defaults to 'LocalMachine'.
 
 ## Versions
 
@@ -44,6 +44,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   * Fixed PSSA Issues as well.
   * Fixed Markdown Linting issues as well.
 * [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode): Enabled Code Coverage Support ([issue #18](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/18)).
+* [Michael Fyffe (@TraGicCode)](https://github.com/TraGicCode): Renamed the 'Scope' Parameter to 'ScopeLevel' since errors are thrown when the MOF file is parsed because 'Scope' is a reserved keyword in the DMTF Specification. ([issue #14](https://github.com/PowerShell/xPowerShellExecutionPolicy/issues/14)).
 
 ### 2.0.0.0
 

--- a/Tests/Integration/MSFT_xPowerShellExecutionPolicy.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xPowerShellExecutionPolicy.Integration.Tests.ps1
@@ -1,0 +1,71 @@
+$script:DSCModuleName = 'xPowerShellExecutionPolicy'
+$script:DSCResourceName = 'MSFT_xPowerShellExecutionPolicy'
+
+#region HEADER
+# Integration Test Template Version: 1.2.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+}
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
+
+#endregion
+
+try
+{
+    #region Integration Tests
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    . $configFile
+
+    Describe "$($script:DSCResourceName)_Integration" {
+        #region DEFAULT TESTS
+        It 'Should compile and apply the MOF without throwing' {
+            {
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+
+                $startDscConfigurationParameters = @{
+                    Path         = $TestDrive
+                    ComputerName = 'localhost'
+                    Wait         = $true
+                    Verbose      = $true
+                    Force        = $true
+                    ErrorAction  = 'Stop'
+                }
+
+                Start-DscConfiguration @startDscConfigurationParameters
+            } | Should -Not -Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration without throwing' {
+            {
+                Get-DscConfiguration -Verbose -ErrorAction Stop
+            } | Should -Not -Throw
+        }
+        #endregion
+
+        It 'Should have set the resource and all the parameters should match' {
+            $current = Get-DscConfiguration | Where-Object {
+                $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+            }
+            $current.ExecutionPolicy      | Should Be 'RemoteSigned'
+            $current.ExecutionPolicyScope | Should Be 'LocalMachine'
+        }
+    }
+    #endregion
+
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    #endregion
+}

--- a/Tests/Integration/MSFT_xPowerShellExecutionPolicy.config.ps1
+++ b/Tests/Integration/MSFT_xPowerShellExecutionPolicy.config.ps1
@@ -1,7 +1,6 @@
 
 # Integration Test Config Template Version: 1.0.0
 configuration MSFT_xPowerShellExecutionPolicy_config {
-    # TODO: Modify ModuleName (e.g. xNetworking)
     Import-DscResource -ModuleName 'xPowerShellExecutionPolicy'
     node localhost {
         xPowerShellExecutionPolicy Integration_Test

--- a/Tests/Integration/MSFT_xPowerShellExecutionPolicy.config.ps1
+++ b/Tests/Integration/MSFT_xPowerShellExecutionPolicy.config.ps1
@@ -1,0 +1,13 @@
+
+# Integration Test Config Template Version: 1.0.0
+configuration MSFT_xPowerShellExecutionPolicy_config {
+    # TODO: Modify ModuleName (e.g. xNetworking)
+    Import-DscResource -ModuleName 'xPowerShellExecutionPolicy'
+    node localhost {
+        xPowerShellExecutionPolicy Integration_Test
+        {
+            ExecutionPolicy      = 'RemoteSigned'
+            ExecutionPolicyScope = 'LocalMachine'
+        }
+    }
+}

--- a/Tests/Unit/MSFT_xPowerShellExecutionpolicy.Tests.ps1
+++ b/Tests/Unit/MSFT_xPowerShellExecutionpolicy.Tests.ps1
@@ -28,10 +28,10 @@ $Global:invalidPolicyThrowMessage += "not belong to the set `"Bypass,Restricted,
 $Global:invalidPolicyThrowMessage += "specified by the ValidateSet attribute. Supply an argument that is in the set and then "
 $Global:invalidPolicyThrowMessage += "try the command again."
 
-$Global:invalidPolicyScopeLevelThrowMessage = "Cannot validate argument on parameter 'ScopeLevel'. The argument `"badParam`" does "
-$Global:invalidPolicyScopeLevelThrowMessage += "not belong to the set `"CurrentUser,LocalMachine,MachinePolicy,Process,UserPolicy`" "
-$Global:invalidPolicyScopeLevelThrowMessage += "specified by the ValidateSet attribute. Supply an argument that is in the set and then "
-$Global:invalidPolicyScopeLevelThrowMessage += "try the command again."
+$Global:invalidPolicyExecutionPolicyScopeThrowMessage = "Cannot validate argument on parameter 'ExecutionPolicyScope'. The argument `"badParam`" does "
+$Global:invalidPolicyExecutionPolicyScopeThrowMessage += "not belong to the set `"CurrentUser,LocalMachine,MachinePolicy,Process,UserPolicy`" "
+$Global:invalidPolicyExecutionPolicyScopeThrowMessage += "specified by the ValidateSet attribute. Supply an argument that is in the set and then "
+$Global:invalidPolicyExecutionPolicyScopeThrowMessage += "try the command again."
 
 # Begin Testing
 try
@@ -60,14 +60,14 @@ try
                 $result.ExecutionPolicy | should be $(Get-ExecutionPolicy)
             }
 
-            It 'Throws when passed an invalid execution policy ScopeLevel' {
-                { Get-TargetResource -ExecutionPolicy $(Get-ExecutionPolicy) -ScopeLevel "badParam" } | should throw $invalidPolicyScopeLevelThrowMessage
+            It 'Throws when passed an invalid execution policy ExecutionPolicyScope' {
+                { Get-TargetResource -ExecutionPolicy $(Get-ExecutionPolicy) -ExecutionPolicyScope "badParam" } | should throw $invalidPolicyExecutionPolicyScopeThrowMessage
             }
 
-            It 'Returns correct execution policy for the correct ScopeLevel' {
-                $result = Get-TargetResource -ExecutionPolicy $(Get-ExecutionPolicy -Scope  'LocalMachine') -ScopeLevel  'LocalMachine'
+            It 'Returns correct execution policy for the correct ExecutionPolicyScope' {
+                $result = Get-TargetResource -ExecutionPolicy $(Get-ExecutionPolicy -Scope  'LocalMachine') -ExecutionPolicyScope  'LocalMachine'
                 $result.ExecutionPolicy | should be $(Get-ExecutionPolicy -Scope 'LocalMachine')
-                $result.ScopeLevel | should be 'LocalMachine'
+                $result.ExecutionPolicyScope | should be 'LocalMachine'
             }
         }
         #endregion
@@ -98,10 +98,10 @@ try
                 Test-TargetResource -ExecutionPolicy $(Get-ExecutionPolicy) | should be $True
             }
 
-            It 'Returns false when current policy does not match desired policy with correct ScopeLevel' {
+            It 'Returns false when current policy does not match desired policy with correct ExecutionPolicyScope' {
                 Mock -CommandName Get-ExecutionPolicy -MockWith { "Restricted" }
 
-                Test-TargetResource -ExecutionPolicy "Bypass" -ScopeLevel 'LocalMachine' | should be $false
+                Test-TargetResource -ExecutionPolicy "Bypass" -ExecutionPolicyScope 'LocalMachine' | should be $false
             }
 
         }
@@ -116,7 +116,7 @@ try
             }
 
             It 'Throws when passed an invalid scope level' {
-                { Set-TargetResource -ExecutionPolicy 'LocalMachine' -ScopeLevel "badParam" } | should throw $invalidScopeThrowMessage
+                { Set-TargetResource -ExecutionPolicy 'LocalMachine' -ExecutionPolicyScope "badParam" } | should throw $invalidScopeThrowMessage
             }
 
             It 'Set-ExecutionPolicy scope warning exception is caught' {
@@ -144,7 +144,7 @@ try
             It 'Sets execution policy in spesified Scope' {
                 Mock -CommandName Set-ExecutionPolicy -MockWith { }
 
-                Set-TargetResource -ExecutionPolicy "Bypass" -ScopeLevel 'LocalMachine'
+                Set-TargetResource -ExecutionPolicy "Bypass" -ExecutionPolicyScope 'LocalMachine'
 
                 Assert-MockCalled -CommandName Set-ExecutionPolicy -Exactly 1 -Scope It
             }

--- a/Tests/Unit/MSFT_xPowerShellExecutionpolicy.Tests.ps1
+++ b/Tests/Unit/MSFT_xPowerShellExecutionpolicy.Tests.ps1
@@ -28,10 +28,10 @@ $Global:invalidPolicyThrowMessage += "not belong to the set `"Bypass,Restricted,
 $Global:invalidPolicyThrowMessage += "specified by the ValidateSet attribute. Supply an argument that is in the set and then "
 $Global:invalidPolicyThrowMessage += "try the command again."
 
-$Global:invalidPolicyScopeThrowMessage = "Cannot validate argument on parameter 'Scope'. The argument `"badParam`" does "
-$Global:invalidPolicyScopeThrowMessage += "not belong to the set `"CurrentUser,LocalMachine,MachinePolicy,Process,UserPolicy`" "
-$Global:invalidPolicyScopeThrowMessage += "specified by the ValidateSet attribute. Supply an argument that is in the set and then "
-$Global:invalidPolicyScopeThrowMessage += "try the command again."
+$Global:invalidPolicyScopeLevelThrowMessage = "Cannot validate argument on parameter 'ScopeLevel'. The argument `"badParam`" does "
+$Global:invalidPolicyScopeLevelThrowMessage += "not belong to the set `"CurrentUser,LocalMachine,MachinePolicy,Process,UserPolicy`" "
+$Global:invalidPolicyScopeLevelThrowMessage += "specified by the ValidateSet attribute. Supply an argument that is in the set and then "
+$Global:invalidPolicyScopeLevelThrowMessage += "try the command again."
 
 # Begin Testing
 try
@@ -60,14 +60,14 @@ try
                 $result.ExecutionPolicy | should be $(Get-ExecutionPolicy)
             }
 
-            It 'Throws when passed an invalid execution policy Scope' {
-                { Get-TargetResource -ExecutionPolicy $(Get-ExecutionPolicy) -Scope "badParam" } | should throw $invalidPolicyScopeThrowMessage
+            It 'Throws when passed an invalid execution policy ScopeLevel' {
+                { Get-TargetResource -ExecutionPolicy $(Get-ExecutionPolicy) -ScopeLevel "badParam" } | should throw $invalidPolicyScopeLevelThrowMessage
             }
 
-            It 'Returns correct execution policy for the correct Scope' {
-                $result = Get-TargetResource -ExecutionPolicy $(Get-ExecutionPolicy -Scope 'LocalMachine') -Scope 'LocalMachine'
+            It 'Returns correct execution policy for the correct ScopeLevel' {
+                $result = Get-TargetResource -ExecutionPolicy $(Get-ExecutionPolicy -Scope  'LocalMachine') -ScopeLevel  'LocalMachine'
                 $result.ExecutionPolicy | should be $(Get-ExecutionPolicy -Scope 'LocalMachine')
-                $result.Scope | should be 'LocalMachine'
+                $result.ScopeLevel | should be 'LocalMachine'
             }
         }
         #endregion
@@ -98,10 +98,10 @@ try
                 Test-TargetResource -ExecutionPolicy $(Get-ExecutionPolicy) | should be $True
             }
 
-            It 'Returns false when current policy does not match desired policy with correct Scope' {
+            It 'Returns false when current policy does not match desired policy with correct ScopeLevel' {
                 Mock -CommandName Get-ExecutionPolicy -MockWith { "Restricted" }
 
-                Test-TargetResource -ExecutionPolicy "Bypass" -Scope 'LocalMachine'| should be $false
+                Test-TargetResource -ExecutionPolicy "Bypass" -ScopeLevel 'LocalMachine' | should be $false
             }
 
         }
@@ -115,8 +115,8 @@ try
                 { Set-TargetResource -ExecutionPolicy 'badParam' } | should throw $invalidPolicyThrowMessage
             }
 
-            It 'Throws when passed an invalid scope' {
-                { Set-TargetResource -ExecutionPolicy 'LocalMachine' -Scope "badParam" } | should throw $invalidScopeThrowMessage
+            It 'Throws when passed an invalid scope level' {
+                { Set-TargetResource -ExecutionPolicy 'LocalMachine' -ScopeLevel "badParam" } | should throw $invalidScopeThrowMessage
             }
 
             It 'Set-ExecutionPolicy scope warning exception is caught' {
@@ -144,7 +144,7 @@ try
             It 'Sets execution policy in spesified Scope' {
                 Mock -CommandName Set-ExecutionPolicy -MockWith { }
 
-                Set-TargetResource -ExecutionPolicy "Bypass" -Scope 'LocalMachine'
+                Set-TargetResource -ExecutionPolicy "Bypass" -ScopeLevel 'LocalMachine'
 
                 Assert-MockCalled -CommandName Set-ExecutionPolicy -Exactly 1 -Scope It
             }


### PR DESCRIPTION
This Fixes #14 

Explanation is detailed within the linked issue above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpowershellexecutionpolicy/15)
<!-- Reviewable:end -->
